### PR TITLE
Add required packages .

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 # 1: install required packages
 # 2: prepare configuration files
-RUN apk --no-cache add ca-certificates gettext libintl postfix rsyslog supervisor \
+RUN apk --no-cache add ca-certificates gettext libintl postfix cyrus-sasl-plain cyrus-sasl-login rsyslog supervisor \
     && cp /usr/bin/envsubst /usr/local/bin/ \
     && apk --no-cache del gettext \
     && ln -fs /root/conf/rsyslog.conf /etc/rsyslog.conf \


### PR DESCRIPTION
From http://postfix.1071664.n5.nabble.com/3-3-0-gt-3-3-2-and-sasl-error-td99775.html#a99805

> Alpine 3.9 splitted package libsasl (which used to contain liblogin and libplain [1]) into 
> three: libsasl [2], cyrus-sasl-plain [3] and cyrus-sasl-login [4].
>
> [1]: https://pkgs.alpinelinux.org/contents?file=&path=&name=libsasl&branch=v3.8&repo=main&arch=x86_64
> [2]: https://pkgs.alpinelinux.org/contents?file=&path=&name=libsasl&branch=v3.9&repo=main&arch=x86_64
> [3]: https://pkgs.alpinelinux.org/contents?file=&path=&name=cyrus-sasl-plain&branch=v3.9&repo=main&arch=x86_64
> [4]: https://pkgs.alpinelinux.org/contents?file=&path=&name=cyrus-sasl-login&branch=v3.9&repo=main&arch=x86_64

The packages cyrus-sasl-plain and cyrus-sasl-login must be installed to prevent

> warning: SASL authentication failure: No worthy mechs found

which results in an error delivering mails to SMTP server.